### PR TITLE
Allow pytorch-yolo2 to run without CUDA present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.bk
 *.o
 *.so
+*.weights
 backup/

--- a/cfg.py
+++ b/cfg.py
@@ -1,5 +1,7 @@
 import torch
+
 from utils import convert2cpu
+
 
 def parse_cfg(cfgfile):
     blocks = []
@@ -10,7 +12,7 @@ def parse_cfg(cfgfile):
         line = line.rstrip()
         if line == '' or line[0] == '#':
             line = fp.readline()
-            continue        
+            continue
         elif line[0] == '[':
             if block:
                 blocks.append(block)
@@ -153,8 +155,11 @@ def print_cfg(blocks):
 def load_conv(buf, start, conv_model):
     num_w = conv_model.weight.numel()
     num_b = conv_model.bias.numel()
-    conv_model.bias.data.copy_(torch.from_numpy(buf[start:start+num_b]));   start = start + num_b
-    conv_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_w])); start = start + num_w
+    conv_model.bias.data.copy_(torch.from_numpy(buf[start:start+num_b]))
+    start += num_b
+    conv_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_w])
+                                      .view(conv_model.weight.size()))
+    start += num_w
     return start
 
 def save_conv(fp, conv_model):
@@ -168,11 +173,22 @@ def save_conv(fp, conv_model):
 def load_conv_bn(buf, start, conv_model, bn_model):
     num_w = conv_model.weight.numel()
     num_b = bn_model.bias.numel()
-    bn_model.bias.data.copy_(torch.from_numpy(buf[start:start+num_b]));     start = start + num_b
-    bn_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_b]));   start = start + num_b
-    bn_model.running_mean.copy_(torch.from_numpy(buf[start:start+num_b]));  start = start + num_b
-    bn_model.running_var.copy_(torch.from_numpy(buf[start:start+num_b]));   start = start + num_b
-    conv_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_w])); start = start + num_w 
+    bn_model.bias.data.copy_(torch.from_numpy(buf[start:start+num_b]))
+    start += num_b
+
+    bn_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_b]))
+    start += num_b
+
+    bn_model.running_mean.copy_(torch.from_numpy(buf[start:start+num_b]))
+    start += num_b
+
+    bn_model.running_var.copy_(torch.from_numpy(buf[start:start+num_b]))
+    start += num_b
+
+    conv_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_w])
+                                      .view(conv_model.weight.size()))
+    start += num_w
+
     return start
 
 def save_conv_bn(fp, conv_model, bn_model):
@@ -193,7 +209,7 @@ def load_fc(buf, start, fc_model):
     num_w = fc_model.weight.numel()
     num_b = fc_model.bias.numel()
     fc_model.bias.data.copy_(torch.from_numpy(buf[start:start+num_b]));     start = start + num_b
-    fc_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_w]));   start = start + num_w 
+    fc_model.weight.data.copy_(torch.from_numpy(buf[start:start+num_w]));   start = start + num_w
     return start
 
 def save_fc(fp, fc_model):

--- a/debug.py
+++ b/debug.py
@@ -1,12 +1,15 @@
 from __future__ import print_function
-import torch.optim as optim
+
 import os
-import torch
+
 import numpy as np
-from darknet import Darknet
+import torch
+import torch.optim as optim
 from PIL import Image
-from utils import image2torch, convert2cpu
 from torch.autograd import Variable
+
+from darknet import Darknet
+from utils import convert2cpu, image2torch
 
 cfgfile = 'face4.1re_95.91.cfg'
 weightfile = 'face4.1re_95.91.conv.15'
@@ -40,13 +43,16 @@ print('--- bn running_var ---')
 print(m.models[0][1].running_var)
 
 m.train()
-m = m.cuda()
+if torch.cuda.is_available():
+    m = m.cuda()
 
 optimizer = optim.SGD(m.parameters(), lr=1e-2, momentum=0.9, weight_decay=0.1)
 
 img = Image.open(imgpath)
 img = image2torch(img)
-img = Variable(img.cuda())
+if torch.cuda.is_available():
+    img = img.cuda()
+img = Variable(img)
 
 target = Variable(label)
 

--- a/demo.py
+++ b/demo.py
@@ -1,8 +1,11 @@
-from utils import *
-from darknet import Darknet
 import cv2
+import torch
 
-def demo(cfgfile, weightfile):
+from darknet import Darknet
+from utils import *
+
+
+def demo(cfgfile, weightfile, use_cuda=torch.cuda.is_available()):
     m = Darknet(cfgfile)
     m.print_network()
     m.load_weights(weightfile)
@@ -15,8 +18,7 @@ def demo(cfgfile, weightfile):
     else:
         namesfile = 'data/names'
     class_names = load_class_names(namesfile)
- 
-    use_cuda = 1
+
     if use_cuda:
         m.cuda()
 
@@ -36,7 +38,7 @@ def demo(cfgfile, weightfile):
             cv2.waitKey(1)
         else:
              print("Unable to read image")
-             exit(-1) 
+             exit(-1)
 
 ############################################
 if __name__ == '__main__':

--- a/detect.py
+++ b/detect.py
@@ -1,11 +1,15 @@
 import sys
 import time
+
+import torch
 from PIL import Image, ImageDraw
+
+from darknet import Darknet
 from models.tiny_yolo import TinyYoloNet
 from utils import *
-from darknet import Darknet
 
-def detect(cfgfile, weightfile, imgfile):
+
+def detect(cfgfile, weightfile, imgfile, use_cuda=torch.cuda.is_available()):
     m = Darknet(cfgfile)
 
     m.print_network()
@@ -18,14 +22,13 @@ def detect(cfgfile, weightfile, imgfile):
         namesfile = 'data/coco.names'
     else:
         namesfile = 'data/names'
-    
-    use_cuda = 1
+
     if use_cuda:
         m.cuda()
 
     img = Image.open(imgfile).convert('RGB')
     sized = img.resize((m.width, m.height))
-    
+
     for i in range(2):
         start = time.time()
         boxes = do_detect(m, sized, 0.5, 0.4, use_cuda)
@@ -36,7 +39,7 @@ def detect(cfgfile, weightfile, imgfile):
     class_names = load_class_names(namesfile)
     plot_boxes(img, boxes, 'predictions.jpg', class_names)
 
-def detect_cv2(cfgfile, weightfile, imgfile):
+def detect_cv2(cfgfile, weightfile, imgfile, use_cuda=torch.cuda.is_available()):
     import cv2
     m = Darknet(cfgfile)
 
@@ -50,15 +53,14 @@ def detect_cv2(cfgfile, weightfile, imgfile):
         namesfile = 'data/coco.names'
     else:
         namesfile = 'data/names'
-    
-    use_cuda = 1
+
     if use_cuda:
         m.cuda()
 
     img = cv2.imread(imgfile)
     sized = cv2.resize(img, (m.width, m.height))
     sized = cv2.cvtColor(sized, cv2.COLOR_BGR2RGB)
-    
+
     for i in range(2):
         start = time.time()
         boxes = do_detect(m, sized, 0.5, 0.4, use_cuda)
@@ -84,14 +86,14 @@ def detect_skimage(cfgfile, weightfile, imgfile):
         namesfile = 'data/coco.names'
     else:
         namesfile = 'data/names'
-    
+
     use_cuda = 1
     if use_cuda:
         m.cuda()
 
     img = io.imread(imgfile)
     sized = resize(img, (m.width, m.height)) * 255
-    
+
     for i in range(2):
         start = time.time()
         boxes = do_detect(m, sized, 0.5, 0.4, use_cuda)
@@ -101,7 +103,6 @@ def detect_skimage(cfgfile, weightfile, imgfile):
 
     class_names = load_class_names(namesfile)
     plot_boxes_cv2(img, boxes, savename='predictions.jpg', class_names=class_names)
-
 
 
 


### PR DESCRIPTION
on Mac laptops, pytorch by default does NOT have CUDA support
instead of hard-coding `use_cuda=1`, should just read the value of `torch.cuda.is_available()` instead

also fixes the unbroadcastable `UserWarning` that torch complains about