### PR TITLE
Adding python3 support

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -229,7 +229,7 @@ class Darknet(nn.Module):
                 loss.anchors = [float(i) for i in anchors]
                 loss.num_classes = int(block['classes'])
                 loss.num_anchors = int(block['num'])
-                loss.anchor_step = len(loss.anchors)/loss.num_anchors
+                loss.anchor_step = len(loss.anchors)//loss.num_anchors
                 loss.object_scale = float(block['object_scale'])
                 loss.noobject_scale = float(block['noobject_scale'])
                 loss.class_scale = float(block['class_scale'])

--- a/darknet.py
+++ b/darknet.py
@@ -29,10 +29,10 @@ class Reorg(nn.Module):
         assert(W % stride == 0)
         ws = stride
         hs = stride
-        x = x.view(B, C, H/hs, hs, W/ws, ws).transpose(3,4).contiguous()
-        x = x.view(B, C, H/hs*W/ws, hs*ws).transpose(2,3).contiguous()
-        x = x.view(B, C, hs*ws, H/hs, W/ws).transpose(1,2).contiguous()
-        x = x.view(B, hs*ws*C, H/hs, W/ws)
+        x = x.view(B, C, H//hs, hs, W//ws, ws).transpose(3,4).contiguous()
+        x = x.view(B, C, H//hs*W//ws, hs*ws).transpose(2,3).contiguous()
+        x = x.view(B, C, hs*ws, H//hs, W//ws).transpose(1,2).contiguous()
+        x = x.view(B, hs*ws*C, H//hs, W//ws)
         return x
 
 class GlobalAvgPool2d(nn.Module):
@@ -84,7 +84,6 @@ class Darknet(nn.Module):
             ind = ind + 1
             #if ind > 0:
             #    return x
-
             if block['type'] == 'net':
                 continue
             elif block['type'] == 'convolutional' or block['type'] == 'maxpool' or block['type'] == 'reorg' or block['type'] == 'avgpool' or block['type'] == 'softmax' or block['type'] == 'connected':
@@ -146,7 +145,7 @@ class Darknet(nn.Module):
                 kernel_size = int(block['size'])
                 stride = int(block['stride'])
                 is_pad = int(block['pad'])
-                pad = (kernel_size-1)/2 if is_pad else 0
+                pad = (kernel_size-1)//2 if is_pad else 0
                 activation = block['activation']
                 model = nn.Sequential()
                 if batch_normalize:

--- a/debug.py
+++ b/debug.py
@@ -3,6 +3,7 @@ import torch.optim as optim
 import os
 import torch
 import numpy as np
+from builtins import range as xrange
 from darknet import Darknet
 from PIL import Image
 from utils import image2torch, convert2cpu

--- a/region_loss.py
+++ b/region_loss.py
@@ -5,12 +5,13 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 from utils import *
+from builtins import range as xrange
 
 def build_targets(pred_boxes, target, anchors, num_anchors, num_classes, nH, nW, noobject_scale, object_scale, sil_thresh, seen):
     nB = target.size(0)
     nA = num_anchors
     nC = num_classes
-    anchor_step = len(anchors)/num_anchors
+    anchor_step = len(anchors)//num_anchors
     conf_mask  = torch.ones(nB, nA, nH, nW) * noobject_scale
     coord_mask = torch.zeros(nB, nA, nH, nW)
     cls_mask   = torch.zeros(nB, nA, nH, nW)
@@ -105,7 +106,7 @@ class RegionLoss(nn.Module):
         self.num_classes = num_classes
         self.anchors = anchors
         self.num_anchors = num_anchors
-        self.anchor_step = len(anchors)/num_anchors
+        self.anchor_step = len(anchors)//num_anchors
         self.coord_scale = 1
         self.noobject_scale = 1
         self.object_scale = 5

--- a/scripts/voc_eval.py
+++ b/scripts/voc_eval.py
@@ -3,10 +3,11 @@
 # Licensed under The MIT License [see LICENSE for details]
 # Written by Bharath Hariharan
 # --------------------------------------------------------
+from __future__ import print_function
 
 import xml.etree.ElementTree as ET
 import os,sys
-import cPickle
+import pickle
 import numpy as np
 
 def parse_rec(filename):
@@ -108,16 +109,16 @@ def voc_eval(detpath,
         for i, imagename in enumerate(imagenames):
             recs[imagename] = parse_rec(annopath.format(imagename))
             if i % 100 == 0:
-                print 'Reading annotation for {:d}/{:d}'.format(
-                    i + 1, len(imagenames))
+                print('Reading annotation for {:d}/{:d}'.format(
+                    i + 1, len(imagenames)))
         # save
-        print 'Saving cached annotations to {:s}'.format(cachefile)
-        with open(cachefile, 'w') as f:
-            cPickle.dump(recs, f)
+        print('Saving cached annotations to {:s}'.format(cachefile))
+        with open(cachefile, 'wb') as f:
+            pickle.dump(recs, f)
     else:
         # load
-        with open(cachefile, 'r') as f:
-            recs = cPickle.load(f)
+        with open(cachefile, 'rb') as f:
+            recs = pickle.load(f)
 
     # extract gt objects for this class
     class_recs = {}
@@ -201,8 +202,7 @@ def voc_eval(detpath,
     
 
 
-def _do_python_eval(res_prefix, output_dir = 'output'):
-    _devkit_path = '/data/xiaohang/pytorch-yolo2/VOCdevkit'
+def _do_python_eval(res_prefix, output_dir = 'output', _devkit_path = 'VOCdevkit'):
     _year = '2007'
     _classes = ('__background__', # always index 0
         'aeroplane', 'bicycle', 'bird', 'boat',
@@ -228,7 +228,7 @@ def _do_python_eval(res_prefix, output_dir = 'output'):
     aps = []
     # The PASCAL VOC metric changed in 2010
     use_07_metric = True if int(_year) < 2010 else False
-    print 'VOC07 metric? ' + ('Yes' if use_07_metric else 'No')
+    print('VOC07 metric? ' + ('Yes' if use_07_metric else 'No'))
     if not os.path.isdir(output_dir):
         os.mkdir(output_dir)
     for i, cls in enumerate(_classes):
@@ -240,8 +240,8 @@ def _do_python_eval(res_prefix, output_dir = 'output'):
             use_07_metric=use_07_metric)
         aps += [ap]
         print('AP for {} = {:.4f}'.format(cls, ap))
-        with open(os.path.join(output_dir, cls + '_pr.pkl'), 'w') as f:
-            cPickle.dump({'rec': rec, 'prec': prec, 'ap': ap}, f)
+        with open(os.path.join(output_dir, cls + '_pr.pkl'), 'wb') as f:
+            pickle.dump({'rec': rec, 'prec': prec, 'ap': ap}, f)
     print('Mean AP = {:.4f}'.format(np.mean(aps)))
     print('~~~~~~~~')
     print('Results:')
@@ -261,6 +261,11 @@ def _do_python_eval(res_prefix, output_dir = 'output'):
 if __name__ == '__main__':
     #res_prefix = '/data/hongji/darknet/project/voc/results/comp4_det_test_'    
     res_prefix = sys.argv[1]
-    _do_python_eval(res_prefix, output_dir = 'output')
+    if len(sys.argv) > 2:
+        _devkit_path = sys.argv[2]
+    else:
+        _devkit_path = 'VOCdevkit'
+
+    _do_python_eval(res_prefix, output_dir = 'output', _devkit_path = _devkit_path)
 
 

--- a/tools/lmdb/create_dataset.py
+++ b/tools/lmdb/create_dataset.py
@@ -3,6 +3,7 @@ import os
 import lmdb # install lmdb by "pip install lmdb"
 import cv2
 import numpy as np
+from builtins import range as xrange
 
 def checkImageIsValid(imageBin):
     if imageBin is None:

--- a/train.py
+++ b/train.py
@@ -50,7 +50,7 @@ steps         = [float(step) for step in net_options['steps'].split(',')]
 scales        = [float(scale) for scale in net_options['scales'].split(',')]
 
 #Train parameters
-max_epochs    = max_batches*batch_size/nsamples+1
+max_epochs    = max_batches*batch_size//nsamples+1
 use_cuda      = True
 seed          = int(time.time())
 eps           = 1e-5
@@ -78,11 +78,11 @@ model.load_weights(weightfile)
 model.print_network()
 
 region_loss.seen  = model.seen
-processed_batches = model.seen/batch_size
+processed_batches = model.seen//batch_size
 
 init_width        = model.width
 init_height       = model.height
-init_epoch        = model.seen/nsamples 
+init_epoch        = model.seen//nsamples 
 
 kwargs = {'num_workers': num_workers, 'pin_memory': True} if use_cuda else {}
 test_loader = torch.utils.data.DataLoader(

--- a/utils.py
+++ b/utils.py
@@ -111,7 +111,7 @@ def convert2cpu_long(gpu_matrix):
     return torch.LongTensor(gpu_matrix.size()).copy_(gpu_matrix)
 
 def get_region_boxes(output, conf_thresh, num_classes, anchors, num_anchors, only_objectness=1, validation=False):
-    anchor_step = len(anchors)/num_anchors
+    anchor_step = len(anchors)//num_anchors
     if output.dim() == 3:
         output = output.unsqueeze(0)
     batch = output.size(0)

--- a/utils.py
+++ b/utils.py
@@ -277,7 +277,7 @@ def read_truths(lab_path):
         return np.array([])
     if os.path.getsize(lab_path):
         truths = np.loadtxt(lab_path)
-        truths = truths.reshape(truths.size/5, 5) # to avoid single truth problem
+        truths = truths.reshape(truths.size//5, 5) # to avoid single truth problem
         return truths
     else:
         return np.array([])

--- a/utils.py
+++ b/utils.py
@@ -390,7 +390,7 @@ def file_lines(thefilepath):
     count = 0
     thefile = open(thefilepath, 'rb')
     while True:
-        buffer = thefile.read(8192*1024)
+        buffer = thefile.read(8192*1024).decode()
         if not buffer:
             break
         count += buffer.count('\n')

--- a/valid.py
+++ b/valid.py
@@ -65,10 +65,10 @@ def valid(datacfg, cfgfile, weightfile, outfile):
                 y2 = (box[1] + box[3]/2.0) * height
 
                 det_conf = box[4]
-                for j in range((len(box)-5)/2):
+                for j in range((len(box)-5)//2):
                     cls_conf = box[5+2*j]
                     cls_id = box[6+2*j]
-                    prob =det_conf * cls_conf
+                    prob = det_conf * cls_conf
                     fps[cls_id].write('%s %f %f %f %f %f\n' % (fileId, prob, x1, y1, x2, y2))
 
     for i in range(m.num_classes):


### PR DESCRIPTION
Related to #36 

Adding the python3 support for demo, training, evaluation
Main fixes:
- integer division:  a/b  -> a//b
- xrange: add 'from builtins import range as xrange'
- cPickle: change to pickle
- print: change to function
- use binary files when reading with pickle
- remove hard-coded path to VOCdevkit  in scripts/voc_eval.py

Tested with both python 3.6 and python 2.7
