### PR TITLE
Python 3 compatibility

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -29,10 +29,10 @@ class Reorg(nn.Module):
         assert(W % stride == 0)
         ws = stride
         hs = stride
-        x = x.view(B, C, H/hs, hs, W/ws, ws).transpose(3,4).contiguous()
-        x = x.view(B, C, H/hs*W/ws, hs*ws).transpose(2,3).contiguous()
-        x = x.view(B, C, hs*ws, H/hs, W/ws).transpose(1,2).contiguous()
-        x = x.view(B, hs*ws*C, H/hs, W/ws)
+        x = x.view(B, C, H//hs, hs, W//ws, ws).transpose(3,4).contiguous()
+        x = x.view(B, C, H//hs*W//ws, hs*ws).transpose(2,3).contiguous()
+        x = x.view(B, C, hs*ws, H//hs, W//ws).transpose(1,2).contiguous()
+        x = x.view(B, hs*ws*C, H//hs, W//ws)
         return x
 
 class GlobalAvgPool2d(nn.Module):

--- a/darknet.py
+++ b/darknet.py
@@ -146,7 +146,7 @@ class Darknet(nn.Module):
                 kernel_size = int(block['size'])
                 stride = int(block['stride'])
                 is_pad = int(block['pad'])
-                pad = (kernel_size-1)/2 if is_pad else 0
+                pad = (kernel_size-1)//2 if is_pad else 0
                 activation = block['activation']
                 model = nn.Sequential()
                 if batch_normalize:

--- a/region_loss.py
+++ b/region_loss.py
@@ -5,6 +5,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 from utils import *
+try:
+    xrange            #python 2 
+except NameError:
+    xrange = range    #python 3
 
 def build_targets(pred_boxes, target, anchors, num_anchors, num_classes, nH, nW, noobject_scale, object_scale, sil_thresh, seen):
     nB = target.size(0)

--- a/region_loss.py
+++ b/region_loss.py
@@ -125,6 +125,7 @@ class RegionLoss(nn.Module):
         nC = self.num_classes
         nH = output.data.size(2)
         nW = output.data.size(3)
+        self.anchor_step = int(self.anchor_step)
 
         output   = output.view(nB, nA, (5+nC), nH, nW)
         x    = F.sigmoid(output.index_select(2, Variable(torch.cuda.LongTensor([0]))).view(nB, nA, nH, nW))

--- a/region_loss.py
+++ b/region_loss.py
@@ -14,7 +14,7 @@ def build_targets(pred_boxes, target, anchors, num_anchors, num_classes, nH, nW,
     nB = target.size(0)
     nA = num_anchors
     nC = num_classes
-    anchor_step = len(anchors)/num_anchors
+    anchor_step = len(anchors)//num_anchors
     conf_mask  = torch.ones(nB, nA, nH, nW) * noobject_scale
     coord_mask = torch.zeros(nB, nA, nH, nW)
     cls_mask   = torch.zeros(nB, nA, nH, nW)

--- a/scripts/voc_eval.py
+++ b/scripts/voc_eval.py
@@ -6,7 +6,10 @@
 
 import xml.etree.ElementTree as ET
 import os,sys
-import cPickle
+try:
+    import cPickle
+except:
+    import pickle as cPickle
 import numpy as np
 
 def parse_rec(filename):

--- a/scripts/voc_eval.py
+++ b/scripts/voc_eval.py
@@ -112,11 +112,11 @@ def voc_eval(detpath,
                     i + 1, len(imagenames)))
         # save
         print ('Saving cached annotations to {:s}'.format(cachefile))
-        with open(cachefile, 'w') as f:
+        with open(cachefile, 'wb') as f:
             cPickle.dump(recs, f)
     else:
         # load
-        with open(cachefile, 'r') as f:
+        with open(cachefile, 'rb') as f:
             recs = cPickle.load(f)
 
     # extract gt objects for this class
@@ -240,7 +240,7 @@ def _do_python_eval(res_prefix, output_dir = 'output'):
             use_07_metric=use_07_metric)
         aps += [ap]
         print('AP for {} = {:.4f}'.format(cls, ap))
-        with open(os.path.join(output_dir, cls + '_pr.pkl'), 'w') as f:
+        with open(os.path.join(output_dir, cls + '_pr.pkl'), 'wb') as f:
             cPickle.dump({'rec': rec, 'prec': prec, 'ap': ap}, f)
     print('Mean AP = {:.4f}'.format(np.mean(aps)))
     print('~~~~~~~~')

--- a/scripts/voc_eval.py
+++ b/scripts/voc_eval.py
@@ -108,10 +108,10 @@ def voc_eval(detpath,
         for i, imagename in enumerate(imagenames):
             recs[imagename] = parse_rec(annopath.format(imagename))
             if i % 100 == 0:
-                print 'Reading annotation for {:d}/{:d}'.format(
-                    i + 1, len(imagenames))
+                print ('Reading annotation for {:d}/{:d}'.format(
+                    i + 1, len(imagenames)))
         # save
-        print 'Saving cached annotations to {:s}'.format(cachefile)
+        print ('Saving cached annotations to {:s}'.format(cachefile))
         with open(cachefile, 'w') as f:
             cPickle.dump(recs, f)
     else:
@@ -228,7 +228,7 @@ def _do_python_eval(res_prefix, output_dir = 'output'):
     aps = []
     # The PASCAL VOC metric changed in 2010
     use_07_metric = True if int(_year) < 2010 else False
-    print 'VOC07 metric? ' + ('Yes' if use_07_metric else 'No')
+    print ('VOC07 metric? ' + ('Yes' if use_07_metric else 'No'))
     if not os.path.isdir(output_dir):
         os.mkdir(output_dir)
     for i, cls in enumerate(_classes):

--- a/train.py
+++ b/train.py
@@ -50,7 +50,7 @@ steps         = [float(step) for step in net_options['steps'].split(',')]
 scales        = [float(scale) for scale in net_options['scales'].split(',')]
 
 #Train parameters
-max_epochs    = max_batches*batch_size/nsamples+1
+max_epochs    = max_batches*batch_size//nsamples+1
 use_cuda      = True
 seed          = int(time.time())
 eps           = 1e-5
@@ -82,7 +82,7 @@ processed_batches = model.seen/batch_size
 
 init_width        = model.width
 init_height       = model.height
-init_epoch        = model.seen/nsamples 
+init_epoch        = model.seen//nsamples 
 
 kwargs = {'num_workers': num_workers, 'pin_memory': True} if use_cuda else {}
 test_loader = torch.utils.data.DataLoader(

--- a/utils.py
+++ b/utils.py
@@ -111,7 +111,7 @@ def convert2cpu_long(gpu_matrix):
     return torch.LongTensor(gpu_matrix.size()).copy_(gpu_matrix)
 
 def get_region_boxes(output, conf_thresh, num_classes, anchors, num_anchors, only_objectness=1, validation=False):
-    anchor_step = len(anchors)/num_anchors
+    anchor_step = len(anchors)//num_anchors
     if output.dim() == 3:
         output = output.unsqueeze(0)
     batch = output.size(0)

--- a/utils.py
+++ b/utils.py
@@ -388,7 +388,7 @@ def scale_bboxes(bboxes, width, height):
       
 def file_lines(thefilepath):
     count = 0
-    thefile = open(thefilepath, 'rb')
+    thefile = open(thefilepath, 'r')
     while True:
         buffer = thefile.read(8192*1024)
         if not buffer:

--- a/valid.py
+++ b/valid.py
@@ -65,7 +65,7 @@ def valid(datacfg, cfgfile, weightfile, outfile):
                 y2 = (box[1] + box[3]/2.0) * height
 
                 det_conf = box[4]
-                for j in range((len(box)-5)/2):
+                for j in range((len(box)-5)//2):
                     cls_conf = box[5+2*j]
                     cls_id = box[6+2*j]
                     prob =det_conf * cls_conf


### PR DESCRIPTION
The purpose of this branch is to add python 3 support for this implementation. There are several compatibility issues which prevent this implementation from successfully executing on python 3. 

1. A lot of code doesn't work because of the way Python 2 and Python 3 handle the `/` (division) operator. The operator performs integer division in Py2, whereas it performs float division in Py3. This causes a lot of problems, because a lot of parameters (like padding, number of epochs, stride, anchor step) need to be integers, but the division operator in Python 3 yields floats. For all these instances, I have found, I've replaced the `/` operator with `//` operator, which performs integer division in both Py2 and Py3. There was an instance where such a thing didn't work (I printed the python type of the parameter before it was passed into the function which was raising the error, it was float), so I had to explicitly typecast the parameter as an int.

2. Some functions that are used exist in python 2, but do not exist in python 3 anymore. In this case, the functions are `xrange` and `cPickle`. I've introduced these issues by using try catch blocks. 

3. There is something about reading and writing files using python's `open` module that works fine with the current implementation in Python2, but the same function throws errors when the code is run in Python 3. These include defining the file to be read as a byte file, and then trying to read a file of the disk that the interpreter recognizes as a string (char?) file. I've simply followed the errors, and fixed the errors by matching up the type of file being read/written and the argument passed to `open`

4. Lack of parenthesis with the `print` function. 

Now, I have not tested the code in it's entirety, as in I've tested only the following parts of code. 

1. Running a test detection `detect.py`
2. Training with `train.py` with ONLY Pascal VOC 2007/2012 database. 
3. Evaluating using `valid.py` and `scripts/voc_eval.py`. I got an mAP of 75.13 with the pre-trained `yolo-voc.weights`

I'm wary about the fact that if compatibility issues are present in code **ONLY** used during COCO training, I will have missed it. I intend to test the code using COCO, but that won't be possible for another week. 

I've tested the code on Python 3.6.3, on a nVidia Tesla K80, and nVidia Quadro K1200 (I coudn't get the network to train on K1200 because the batch size was too big to fit into VRAM, and I was being lazy). 
 

